### PR TITLE
Move disabling of autocomplete from HTML to JavaScript

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
 				<h1>Minimal Form Interface <span>Simplistic, single input view form</span></h1>	
 			</header>
 			<section>
-				<form id="theForm" class="simform" autocomplete="off">
+				<form id="theForm" class="simform">
 					<div class="simform-inner">
 						<ol class="questions">
 							<li>
@@ -83,6 +83,8 @@
 		<script src="js/stepsForm.js"></script>
 		<script>
 			var theForm = document.getElementById( 'theForm' );
+                        //disable form autocomplete
+                        theForm.setAttribute( "autocomplete", "off" );
 
 			new stepsForm( theForm, {
 				onSubmit : function( form ) {


### PR DESCRIPTION
I'm not sure if this matters to anyone or not.  I thought it might be a good idea to remove the hard-coded autocomplete attribute from the form element and add it with JavaScript instead.  There no point disabling a browser feature unnecessarily since it's only required when JS is enabled.  Autocomplete is also a non-standard attribute prior to HTML5 so this could prevent validation if someone expands this project to work on pre-existing forms (as a jQuery plugin, for instance).
