### PR TITLE
prevent character submission after enter/return

### DIFF
--- a/js/stepsForm.js
+++ b/js/stepsForm.js
@@ -129,8 +129,8 @@
 			// clear any previous error messages
 			input.setCustomValidity( '' );
 			
-      // disable input box to prevent character submission after keyDown 13
-      input.disabled = true;
+			// prevent character submission after keyDown 13
+      input.readOnly = true;
 			// checks input against the validation constraint
 			if ( !input.checkValidity() ) {
 				// Optionally, set a custom HTML5 valiation message
@@ -138,8 +138,6 @@
 				input.setCustomValidity( 'Whoops, that\'s not an email address!' );
 				// display the HTML5 error message
 				this._showError( input.validationMessage );
-				// re-enable input
-        input.disabled = false;
 				// prevent the question from changing
 				return false;
 			}

--- a/js/stepsForm.js
+++ b/js/stepsForm.js
@@ -129,6 +129,8 @@
 			// clear any previous error messages
 			input.setCustomValidity( '' );
 			
+      // disable input box to prevent character submission after keyDown 13
+      input.disabled = true;
 			// checks input against the validation constraint
 			if ( !input.checkValidity() ) {
 				// Optionally, set a custom HTML5 valiation message
@@ -136,6 +138,8 @@
 				input.setCustomValidity( 'Whoops, that\'s not an email address!' );
 				// display the HTML5 error message
 				this._showError( input.validationMessage );
+				// re-enable input
+        input.disabled = false;
 				// prevent the question from changing
 				return false;
 			}


### PR DESCRIPTION
prevent entering input on nextQuestion.
When an input is submitted, it's currently possible to enter characters after enter; during the animation, which subsequently get posted to the server.
